### PR TITLE
Use OpenSSL 1.1.1i

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+name: Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag-name:
+        description: 'The name of the tag to create with the results of the build'
+        required: true
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Build archs
+      run: sh ./build-libssl.sh --cleanup
+
+    - name: Package XCFramework
+      run: sh ./create-openssl-framework.sh dynamic
+
+    - name: Zip XCFramework
+      run: ditto -c -k -X -rsrc --keepParent ./frameworks/openssl.xcframework ./frameworks/openssl.xcframework.zip
+
+    - name: Compute package checksum
+      run: |
+        checksum=$(swift package compute-checksum ./frameworks/openssl.xcframework.zip)
+        sed -i -E "s/\(checksum: \).*/\1\"$checksum\"/" Package.swift
+        rm -rf Package.swift-E
+
+    - name: Commit new package checksum
+      id: commit_checksum
+      if: ${{ github.event.inputs.tag-name != '' }}
+      run: |
+        git stage Package.swift
+        git commit -m "Update binary target checksum"
+        git push origin master
+
+        last_commit_sha=$(git rev-parse HEAD)
+        echo "::set-output name=last_commit_sha::$last_commit_sha"
+
+    - name: Create a Release
+      id: create_release
+      if: ${{ github.event.inputs.tag-name != '' }}
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.event.inputs.tag-name }}
+        commitish: ${{ steps.commit_checksum.outputs.last_commit_sha }}
+
+    - name: Upload Release Asset
+      id: upload-release-asset
+      if: ${{ github.event.inputs.tag-name != '' }}
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./frameworks/openssl.xcframework.zip
+        asset_name: openssl.xcframework.zip
+        asset_content_type: application/zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Build archs
-      run: sh ./build-libssl.sh --cleanup
+      run: sh ./build-libssl.sh --cleanup --verbose-on-error
 
     - name: Package XCFramework
       run: sh ./create-openssl-framework.sh dynamic

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 bin
 src
 lib
+.build
 frameworks
 include/openssl
 *.gz

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "GXOpenSSL",
+	platforms: [
+		.macOS(.v10_11), .iOS(.v9), .tvOS(.v11), .watchOS(.v4)
+	],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "GXOpenSSL",
+            targets: ["OpenSSL"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+		.binaryTarget(
+			name: "OpenSSL",
+			url: "https://github.com/jechague/GXOpenSSL/releases/download/1.1.1i/openssl.xcframework.zip",
+			checksum: ""
+		)
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![macOS Catalyst support](https://img.shields.io/badge/macOS%20Catalyst-10.15+-blue.svg)
 ![watchOS support](https://img.shields.io/badge/watchOS-4.0+-blue.svg)
 ![tvOS support](https://img.shields.io/badge/tvOS-12+-blue.svg)
-![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.1.1h-green.svg)
+![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.1.1i-green.svg)
 [![license](https://img.shields.io/badge/license-Apache%202.0-lightgrey.svg)](LICENSE)
 
 This is a fork of the popular work by [Felix Schulze](https://github.com/x2on), that is a set of scripts for using self-compiled builds of the OpenSSL library on the iPhone and the Apple TV.

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -29,15 +29,15 @@ DEFAULTVERSION="1.1.1i"
 
 # Default (=full) set of targets (OpenSSL >= 1.1.1) to build
 DEFAULTTARGETS=`cat <<TARGETS
-ios-sim-cross-x86_64 ios-sim-cross-arm64 ios64-cross-arm64 ios64-cross-arm64e
+ios-sim-cross-x86_64 ios-sim-cross-arm64 ios-sim-cross-i386 ios-cross-armv7s ios-cross-armv7 ios64-cross-arm64 ios64-cross-arm64e
 macos64-x86_64 macos64-arm64
 mac-catalyst-x86_64 mac-catalyst-arm64
-watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-x86_64 watchos-sim-cross-i386
-tvos-sim-cross-x86_64 tvos64-cross-arm64
+watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-x86_64 watchos-sim-cross-i386 watchos-sim-cross-arm64
+tvos-sim-cross-x86_64 tvos-sim-cross-arm64 tvos64-cross-arm64
 TARGETS`
 
 # Minimum iOS/tvOS SDK version to build for
-IOS_MIN_SDK_VERSION="12.0"
+IOS_MIN_SDK_VERSION="10.0"
 MACOS_MIN_SDK_VERSION="10.15"
 CATALYST_MIN_SDK_VERSION="10.15"
 WATCHOS_MIN_SDK_VERSION="4.0"
@@ -582,11 +582,17 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
       *_watchos_sim_i386.h)
         DEFINE_CONDITION="TARGET_OS_SIMULATOR && TARGET_CPU_X86 || TARGET_OS_EMBEDDED"
       ;;
+      *_watchos_sim_arm64.h)
+        DEFINE_CONDITION="TARGET_OS_SIMULATOR && TARGET_CPU_ARM64 || TARGET_OS_EMBEDDED"
+      ;;
       *_tvos_arm64.h)
         DEFINE_CONDITION="TARGET_OS_TV && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64"
       ;;
       *_tvos_sim_x86_64.h)
         DEFINE_CONDITION="TARGET_OS_TV && TARGET_OS_SIMULATOR && TARGET_CPU_X86_64"
+      ;;
+      *_tvos_sim_arm64.h)
+        DEFINE_CONDITION="TARGET_OS_TV && TARGET_OS_SIMULATOR && TARGET_CPU_ARM64"
       ;;
       *)
         # Don't run into unexpected cases by setting the default condition to false

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -25,7 +25,7 @@ set -u
 # SCRIPT DEFAULTS
 
 # Default version in case no version is specified
-DEFAULTVERSION="1.1.1h"
+DEFAULTVERSION="1.1.1i"
 
 # Default (=full) set of targets (OpenSSL >= 1.1.1) to build
 DEFAULTTARGETS=`cat <<TARGETS

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -73,15 +73,7 @@ my %targets = ();
 
     ## Apple macOS
 
-    # Base (arm64)
-    "darwin64-arm64-cc" => {
-        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
-        CFLAGS           => add("-Wall"),
-        cflags           => add("-arch arm64"),
-        lib_cppflags     => add("-DL_ENDIAN"),
-        bn_ops           => "SIXTY_FOUR_BIT_LONG",
-        perlasm_scheme   => "ios64",
-    },
+    # Base (arm64): no longer needed as it's defined directly on OpenSSL source
 
     # Device
     "macos64-x86_64" => {

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -46,6 +46,18 @@ my %targets = ();
     ## Apple iOS
 
     # Device
+    "ios-cross-armv7s" => {
+        inherit_from     => [ "darwin-common", "ios-cross-base", asm("armv4_asm") ],
+        cflags           => add("-arch armv7s"),
+        perlasm_scheme   => "ios32",
+        sys_id           => "iOS",
+    },
+    "ios-cross-armv7" => {
+        inherit_from     => [ "darwin-common", "ios-cross-base", asm("armv4_asm") ],
+        cflags           => add("-arch armv7"),
+        perlasm_scheme   => "ios32",
+        sys_id           => "iOS",
+    },
     "ios64-cross-arm64" => {
         inherit_from     => [ "darwin-common", "ios-cross-base", asm("aarch64_asm") ],
         cflags           => add("-arch arm64"),
@@ -63,6 +75,11 @@ my %targets = ();
     # Simulator
     "ios-sim-cross-x86_64" => {
         inherit_from     => [ "darwin64-x86_64-cc", "ios-cross-base" ],
+        sys_id           => "iOS",
+    },
+    "ios-sim-cross-i386" => {
+        inherit_from     => [ "darwin-common", "ios-cross-base" ],
+        cflags           => add("-arch i386"),
         sys_id           => "iOS",
     },
     "ios-sim-cross-arm64" => {
@@ -132,6 +149,12 @@ my %targets = ();
         defines          => [ "HAVE_FORK=0" ],
         sys_id           => "WatchOS",
     },
+    "watchos-sim-cross-arm64" => {
+        inherit_from     => [ "darwin64-arm64-cc", "watchos-cross-base"],
+        cflags           => add("-target arm64-apple-watchos-simulator -fembed-bitcode"),
+        defines          => [ "HAVE_FORK=0" ],
+        sys_id           => "WatchOS",
+    },
 
     ## Apple TV
 
@@ -146,6 +169,11 @@ my %targets = ();
     # Simulator
     "tvos-sim-cross-x86_64" => {
         inherit_from     => [ "darwin64-x86_64-cc", "tvos-cross-base" ],
+        sys_id           => "tvOS",
+    },
+    "tvos-sim-cross-arm64" => {
+        inherit_from     => [ "darwin64-arm64-cc", "tvos-cross-base", asm("aarch64_asm")],
+        cflags           => add("-arch arm64 -target arm64-apple-tvos-simulator -mtvos-version-min=11.0"),
         sys_id           => "tvOS",
     },
 );


### PR DESCRIPTION
This PR also adds more build ARCHS (needed for linking the resulting XCFramework with frameworks or apps with a MINIMUM_DEPLOYMENT_TARGET of iOS 9.0 or above.

Allow consuming the repository as a Swift Package

Define a GitHub Actions workflow to build and release the resulting XCFramework.